### PR TITLE
Make container widths for pages export narrower

### DIFF
--- a/website/assets/_variables.scss
+++ b/website/assets/_variables.scss
@@ -1,5 +1,5 @@
 $body-min-width: 20rem;
-$container-max-width: 5000rem;
+$container-max-width: 110rem;
 
-$menu-width: 20rem;
-$toc-width: 20rem;
+$menu-width: 15rem;
+$toc-width: 15rem;


### PR DESCRIPTION
Let the bikeshedding begin :)

This is what the current design looks like on a ultrawide screen with a width of 3840 pixels.

![now](https://user-images.githubusercontent.com/1044766/197280845-968cade4-b669-42b8-aa77-ea8ef46de12a.png)

The changes from this PR look like this on the same screen at full width

![3840_110_15](https://user-images.githubusercontent.com/1044766/197280959-500d74f2-f972-48fa-9f56-0117418b23a2.png)

at half width (1820 pixels, somewhat close to Full HD)

![1820_110_15](https://user-images.githubusercontent.com/1044766/197280997-8ad57126-63df-48cf-a881-a9112c91ca54.png)

and on a 14 inch laptop screen with a width of 2560 pixels 

![2560_110_15](https://user-images.githubusercontent.com/1044766/197281135-b3c1c27e-027e-408b-9332-c5ccf82ca967.png)
