### PR TITLE
website: base URL uapi-group.org, fix spec link

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -1,4 +1,4 @@
-baseURL = "https://uapi-group.github.io/specifications"
+baseURL = "https://uapi-group.org/specifications"
 languageCode = "en-us"
 title = "UAPI Group Specifications"
 theme = "hugo-book"

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -12,7 +12,7 @@ Featured Specs:
   Defines a set  of file formats and naming conventions to allow distribution independent boot loader menus supportable by multiple bootloaders.
 * [Base directory specification](docs/base_directory_specification):
   Standardises default locations and environment variables for locating common files or base directories.
-* [Discoverable partitions specification](docs/discoverable_partitions):
+* [Discoverable partitions specification](docs/discoverable_partitions_specification):
   Discusses GUID UUIDs for auto-discovery of partition semantics and mount points.
 
 ## Work in Progress


### PR DESCRIPTION
Set the base URL of the specs repo website to use uapi-group/specifications, and fix a link on the index page to the discoverable partitions spec.