### PR TITLE
website: fix 'Edit this page' links

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -27,6 +27,6 @@ theme = "hugo-book"
   BookSection = '*'
   BookRepo = 'https://github.com/uapi-group/specifications'
   BookCommitPath = 'commit'
-  BookEditPath = 'edit/main/specs'
+  BookEditPath = 'edit/main'
   BookDateFormat = 'Jan 2, 2006'
   BookIndexPage = 'README.md'


### PR DESCRIPTION
Current links to edit pages on Github have an extra `/specs` in the URL.