### PR TITLE
specs: import the table of PCRs 0—7 from systemd-cryptenroll(8)

### DIFF
--- a/specs/linux_tpm_pcr_registry.md
+++ b/specs/linux_tpm_pcr_registry.md
@@ -8,7 +8,9 @@ SPDX-License-Identifier: CC0-1.0
 
 _TPM PCRs are a scarce resource, there are only 24 of them in typical standards compliant TPMs. According to the [TCG PC Client Specific Platform Firmware Profile Specification | Trusted Computing Group](https://trustedcomputinggroup.org/resource/pc-client-specific-platform-firmware-profile-specification/) PCRs 8…15 are for the OS to make use of. In this document we intend to document for Linux platforms which component is using which PCR in order to minimize conflicts._
 
-Out of scope for this is how other OSes, in particular Windows’ use the PCRs. Also out of scope are PCRs owned by the firmware, i.e. 0...7.
+PCRs owned by the firmware, i.e. PCRs 0–7 are described here just for convenience.
+The authoriative description is in the TCG document.
+How other operating systems — in particular Windows — use PCRs, is out of scope of this document.
 
 This document is informational in nature: it just describes what is, it is not intended to formally declare “ownership” of a specific PCR, but simply is supposed to reflect which PCR assignments are common in the Linux ecosystems. That said, co-opting PCR usage will likely create problems down the line, in particular if measurement logs are maintained separately. (To be more explicit: on `systemd` systems the warranty is voided if you write to the PCRs it also uses, as per the list below.)
 
@@ -28,6 +30,70 @@ In both cases it is important that data measured into the PCRs is carefully chos
    <th><strong>Log</strong></th>
    <th><strong>Use Reported By</strong></th>
   </tr>
+
+  <tr>
+   <td style="background-color:#fff3bf;"><p style="text-align: right"><strong>0</strong></p></td>
+   <td style="background-color:#AEA;"><code style="background-color:#AEA;">Firmware 💻</code></td>
+   <td>UEFI Boot Component</td>
+   <td>Core system firmware executable code</td>
+   <td>UEFI TPM event log</td>
+   <td>n/a</td>
+  </tr>
+
+  <tr>
+   <td style="background-color:#fff3bf;"><p style="text-align: right"><strong>1</strong></p></td>
+   <td style="background-color:#838284;"><code style="background-color:#838284;">Firmware 💻</code></td>
+   <td>UEFI Boot Component</td>
+   <td>Core system firmware data/host platform configuration; typically contains serial and model numbers</td>
+   <td>UEFI TPM event log</td>
+   <td>n/a</td>
+  </tr>
+
+  <tr>
+   <td style="background-color:#fff3bf;"><p style="text-align: right"><strong>2</strong></p></td>
+   <td style="background-color:#838284;"><code style="background-color:#838284;">Firmware 💻</code></td>
+   <td>UEFI Boot Component</td>
+   <td>Extended or pluggable executable code; includes option ROMs on pluggable hardware</td>
+   <td>UEFI TPM event log</td>
+   <td>n/a</td>
+  </tr>
+
+  <tr>
+   <td style="background-color:#fff3bf;"><p style="text-align: right"><strong>3</strong></p></td>
+   <td style="background-color:#838284;"><code style="background-color:#838284;">Firmware 💻</code></td>
+   <td>UEFI Boot Component</td>
+   <td>Extended or pluggable firmware data; includes information about pluggable hardware</td>
+   <td>UEFI TPM event log</td>
+   <td>n/a</td>
+  </tr>
+
+  <tr>
+   <td style="background-color:#fff3bf;"><p style="text-align: right"><strong>4</strong></p></td>
+   <td style="background-color:#838284;"><code style="background-color:#838284;">Firmware 💻</code></td>
+   <td>UEFI Boot Component</td>
+   <td>Boot loader and additional drivers; binaries and extensions loaded by the boot loader</td>
+   <td>UEFI TPM event log</td>
+   <td>n/a</td>
+  </tr>
+
+  <tr>
+   <td style="background-color:#fff3bf;"><p style="text-align: right"><strong>5</strong></p></td>
+   <td style="background-color:#838284;"><code style="background-color:#838284;">Firmware 💻</code></td>
+   <td>UEFI Boot Component</td>
+   <td>GPT/Partition table</td>
+   <td>UEFI TPM event log</td>
+   <td>n/a</td>
+  </tr>
+
+  <tr>
+   <td style="background-color:#fff3bf;"><p style="text-align: right"><strong>7</strong></p></td>
+   <td style="background-color:#838284;"><code style="background-color:#838284;">Firmware 💻</code></td>
+   <td>UEFI Boot Component</td>
+   <td>SecureBoot state</td>
+   <td>UEFI TPM event log</td>
+   <td>n/a</td>
+  </tr>
+
   <tr>
    <td style="background-color:#fff3bf;"><p style="text-align: right"><strong>8</strong></p></td>
    <td style="background-color:#AEA;"><code style="background-color:#AEA;">grub 🍲</code></td>
@@ -36,6 +102,7 @@ In both cases it is important that data measured into the PCRs is carefully chos
    <td>UEFI TPM event log</td>
    <td>n/a</td>
   </tr>
+
   <tr>
    <td style="background-color:#fff3bf;"><p style="text-align: right"><strong>9</strong></p></td>
    <td style="background-color:#AEA;"><code style="background-color:#AEA;">grub 🍲</code></td>
@@ -44,14 +111,16 @@ In both cases it is important that data measured into the PCRs is carefully chos
    <td>UEFI TPM event log</td>
    <td>n/a</td>
   </tr>
+
   <tr>
-   <td style="background-color:#fff3bf;"><p style="text-align: right"><strong>(cont.)</strong></p></td>
+   <td style="background-color:#fff3bf;"></td>
    <td style="background-color:#b399c2;">Linux kernel 🌰</td>
    <td>Kernel</td>
    <td>All passed initrds (when the new <code>LOAD_FILE2 </code>initrd protocol is used)</td>
    <td>UEFI TPM event log</td>
    <td>n/a</td>
   </tr>
+
   <tr>
    <td style="background-color:#fff3bf;"><p style="text-align: right"><strong>10</strong></p></td>
    <td style="background-color:#a3c2d4;">IMA 📐</td>
@@ -60,6 +129,7 @@ In both cases it is important that data measured into the PCRs is carefully chos
    <td>IMA event log</td>
    <td>n/a</td>
   </tr>
+
   <tr>
    <td style="background-color:#fff3bf;"><p style="text-align: right"><strong>11</strong></p></td>
    <td style="background-color:#e5c8e6;"><code style="background-color:#e5c8e6;">systemd-stub 🚀</code></td>
@@ -68,14 +138,16 @@ In both cases it is important that data measured into the PCRs is carefully chos
    <td>UEFI TPM event log</td>
    <td>in EFI variable <code>StubPcrKernelImage</code></td>
   </tr>
+
   <tr>
-   <td style="background-color:#fff3bf;"><p style="text-align: right"><strong>(cont.)</strong></p></td>
+   <td style="background-color:#fff3bf;"></td>
    <td style="background-color:#e5c8e6;"><code style="background-color:#e5c8e6;">systemd-pcrphase 🚀</code></td>
    <td>Userspace</td>
    <td>Boot phase strings, indicating various milestones of the boot process</td>
    <td>Journal (for now)</td>
    <td>n/a</td>
   </tr>
+
   <tr>
    <td style="background-color:#fff3bf;"><p style="text-align: right"><strong>12</strong></p></td>
    <td style="background-color:#e5c8e6;"><code style="background-color:#e5c8e6;">systemd-stub 🚀</code></td>
@@ -84,6 +156,7 @@ In both cases it is important that data measured into the PCRs is carefully chos
    <td>UEFI TPM event log</td>
    <td>in EFI variable <code>StubPcrKernelParameters</code></td>
   </tr>
+
   <tr>
    <td style="background-color:#fff3bf;"><p style="text-align: right"><strong>13</strong></p></td>
    <td style="background-color:#e5c8e6;"><code style="background-color:#e5c8e6;">systemd-stub 🚀</code></td>
@@ -91,6 +164,7 @@ In both cases it is important that data measured into the PCRs is carefully chos
    <td>All system extension images for the initrd</td><td>UEFI TPM event log</td>
    <td>in EFI variable <code>StubPcrInitRDSysExts</code></td>
   </tr>
+
   <tr>
    <td style="background-color:#fff3bf;"><p style="text-align: right"><strong>14</strong></p></td>
    <td style="background-color:#f5d97d;"><code style="background-color:#f5d97d;">shim 🔑</code></td>
@@ -99,6 +173,7 @@ In both cases it is important that data measured into the PCRs is carefully chos
    <td>UEFI TPM event log</td>
    <td>n/a</td>
   </tr>
+
   <tr>
    <td style="background-color:#fff3bf;"><p style="text-align: right"><strong>15</strong></p></td>
    <td style="background-color:#e5c8e6;"><code style="background-color:#e5c8e6;">systemd-cryptsetup@.service 🚀</code></td>
@@ -107,16 +182,18 @@ In both cases it is important that data measured into the PCRs is carefully chos
    <td>Journal (for now)</td>
    <td>n/a</td>
   </tr>
+
   <tr>
-   <td style="background-color:#fff3bf;"><p style="text-align: right"><strong> (cont.)</strong></p> </td>
+   <td style="background-color:#fff3bf;"></td>
    <td style="background-color:#e5c8e6;"><code style="background-color:#e5c8e6;">systemd-pcrmachine.service 🚀</code></td>
    <td>Userspace</td>
    <td>Machine ID (<code>/etc/machine-id</code>)</td>
    <td>Journal (for now)</td>
    <td>n/a</td>
   </tr>
+
   <tr>
-   <td style="background-color:#fff3bf;"><p style="text-align: right"><strong>(cont.)</strong></p></td>
+   <td style="background-color:#fff3bf;"></td>
    <td style="background-color:#e5c8e6;"><code style="background-color:#e5c8e6;">systemd-pcrfs@.service 🚀</code></td>
    <td>Userspace</td>
    <td>File system mount point, UUID, label, partition UUID label of root file system and <code>/var/</code></td>
@@ -125,7 +202,23 @@ In both cases it is important that data measured into the PCRs is carefully chos
   </tr>
 </table>
 
-Note that PCR 11 and 15 as shown in the list above are used by multiple components of systemd. These are not conflicting uses, but the involved components are properly ordered to guarantee cooperative, strictly predictable behaviour.
+PCR 0 changes on firmware updates; PCR 1 changes on basic hardware/CPU/RAM replacements.
+
+PCR 4 changes on boot loader updates.
+The shim project will measure the PE binary it chain loads into this PCR.
+If the Linux kernel is invoked as UEFI PE binary, it is measured here, too.
+[systemd-stub](https://www.freedesktop.org/software/systemd/man/systemd-stub.html)
+measures system extension images read from the ESP here too
+(see [systemd-sysext](https://www.freedesktop.org/software/systemd/man/systemd-sysext.html)).
+
+PCR 5 changes when partitions are added, modified, or removed.
+
+PCR 7 changes when UEFI SecureBoot mode is enabled/disabled, or firmware certificates (PK, KEK, db, dbx, …) are updated.
+The shim project will measure most of its (non-MOK) certificates and SBAT data into this PCR.
+
+PCR 11 and 15 as shown in the list above are used by multiple components of systemd.
+These are not conflicting uses;
+the involved components are properly ordered to cooperatively guarantee predictable behaviour.
 
 ## Sources
 * [systemd-cryptenroll(1)](https://www.freedesktop.org/software/systemd/man/systemd-cryptenroll.html#--tpm2-pcrs=PCR)


### PR DESCRIPTION
This table is informative anyway. If somebody wants to make any realistic use of it, they will usually want a full list of PCRs, because policies bind to e.g. PCR 7 too. So let's copy in the remaining part from systemd-cryptenroll(8). In the preamble it is mentioned that the list here is not authoritative.

In the man page, the discussion of when various PCRs change was included directly in the table. It's tough to squeeze the extra text into the table, so I moved after the table.

I dropped "(cont.d)" for the first row. When the table is rendered, an empty field is visually clearer than the text.

https://sembr.org/ is used for wrapping.