### PR TITLE
UKI: define a location for centrally built UKIs

### DIFF
--- a/specs/unified_kernel_image.md
+++ b/specs/unified_kernel_image.md
@@ -111,3 +111,12 @@ individual resources listed above at once, and their combination. Standard Linux
 [`sbsigntool`](https://manpages.debian.org/unstable/sbsigntool/sbsign.1.en.html) and
 [`pesign`](https://github.com/rhboot/pesign) can be used to sign UKI files. The signature format and process
 again match the ones already used for PE files, so they will not be redefined here.
+
+## Distribution-built UKIs Installed by Package Managers
+
+UKIs that are built centrally by distributions and installed via the package manager should be installed in
+`/usr/lib/modules/$UNAME/`, where `$UNAME` is the output of `uname -r` of the kernel included in the UKI, so
+that tools staging or consuming UKIs have a common place to store and look for them.
+
+The installed UKIs should have a filename `<version format specification>.efi`, i.e. the filename is left to
+implementers but must be valid for comparisons according to the [Version Format Specification](version_format_specification.md).


### PR DESCRIPTION
We were discussing in mkosi how to handle distribution-supplied UKIs in the future. It would be helpful to have a common location that producers can put them in and consumers can look for them. 

I'm open to a different location or naming scheme, the point is rather that there is a standard. 

I didn't touch on the UKI being installed to the ESP or XBOOTLDR directly (in Debian land dpkg can't even do that) - it would be possible within the *should* though -, but I think the general way would be for the package manager to put the UKI in the standard location and kernel-install or a tool like it, to marry it to local configuration (e.g. number of tries for boot counting) and putting it where it should go (ESP or XBOOTLDR). 