### PR TITLE
Caret comparison

### DIFF
--- a/specs/version_format_specification.md
+++ b/specs/version_format_specification.md
@@ -55,7 +55,7 @@ strings are found to compare as different. In a loop:
    the string with `-` compares lower. Otherwise, both minus characters are skipped.
 5. If the remaining part of one of strings starts with `^`:
    if the other remaining part does not start with `^`,
-   the string with `^` compares higher. Otherwise, both caret characters are skipped.
+   the string with `^` compares lower. Otherwise, both caret characters are skipped.
 6. If the remaining part of one of strings starts with `.`:
    if the other remaining part does not start with `.`,
    the string with `.` compares lower. Otherwise, both dot characters are skipped.

--- a/specs/version_format_specification.md
+++ b/specs/version_format_specification.md
@@ -119,6 +119,11 @@ Note how in the `1_2_3` > `1.3.3` and `1+2+3` > `1.3.3` cases, the underscore an
 separators between components, so we first compare `1` with `1.3.3` as numerical version strings, and
 `1` < `1.3.3`. The remainder of the first string is not used in the comparison.
 
+* `122.1` < `123~rc1-1` < `123` < `123-a` < `123-a.1` < `123-1` < `123-1.1` < `123^post1` < `123.a-1` < `123.1-1` < `123a-1` < `124-1`
+
+In the above example each entry compares smaller than every entry to its right and equal only to itself,
+conversely each entry compares larger to every entry to its left and compares unequal to all except itself.
+
 ## Notes
 [systemd-analyze](https://www.freedesktop.org/software/systemd/man/systemd-analyze.html)
 implements this version comparison algorithm as


### PR DESCRIPTION
Looking at the reference implementation in `systemd-analyze compare-versions` the code handling the caret character is the same as for `-` and `.`, right before and after:

```C
        /* Handle '-', which separates version and release, e.g 123.4-3.1.fc33.x86_64 */
        if (*a == '-' || *b == '-') {
                /* The string prefixed with '-' is older (e.g., 123-9 vs 123.1-1) */
                r = CMP(*a != '-', *b != '-');
                if (r != 0)
                        return r;

                a++;
                b++;
        }

        /* Handle '^'. Used for patched release. */
        if (*a == '^' || *b == '^') {
                r = CMP(*a != '^', *b != '^');
                if (r != 0)
                        return r;

                a++;
                b++;
        }

        /* Handle '.'. Used for point releases. */
        if (*a == '.' || *b == '.') {
                r = CMP(*a != '.', *b != '.');
                if (r != 0)
                        return r;

                a++;
                b++;
        }
```

so the caret character must be treated the same in the spec as well. This is not a bug in the reference implementation, since when the sign of the comparison is inverted, i.e. caret compares higher than not-caret, the comparison

- `123^post1` < `123.a-1`

would *not* hold true anymore, since `^` would win against `.` at step 5. This comparison must hold true, to be compatible with `rpmdev-vercmp`

Note: `rpmdev-vercmp` does compare `123^post1` < `123.a-1`, but compares `^` > `.`, which `systemd-analyze` compares `^` < `.`

This PR also adds an extended example taken from a comment of the function implementing this in systemd-analyze, which I found helpful.