### PR TITLE
UKI: document the case of multiple Device Trees

### DIFF
--- a/specs/unified_kernel_image.md
+++ b/specs/unified_kernel_image.md
@@ -48,10 +48,12 @@ UKIs consist of the following resources:
 * Optionally, information describing the OS this kernel is intended for, in the `.osrel` section. The contents of this section are derived from `/etc/os-release` of the target OS. They can be useful for presentation of the UKI in the boot loader menu, and ordering it against other entries using the included version information.
 * Optionally, information describing kernel release information (i.e. `uname -r` output) in the `.uname` section. This is also useful for presentation of the UKI in the boot loader menu, and ordering it against other entries.
 * Optionally, a splash image to bring to screen before transitioning into the Linux kernel, in the `.splash` section.
-* Optionally, a compiled Devicetree database file, for systems which need it, in the `.dtb` section.
+* Optionally, one or more compiled Device Trees, for systems which need it, each in its separate `.dtb` section. If multiple `.dtb` sections exist then one of them is selected according to an implementation-specific algorithm.
 * Optionally, the public part of a public-private key pair in PEM format used to sign the image, in the `.pcrpkey` section.
 * Optionally, a JSON file encoding expected PCR 11 hash values seen from userspace once the UKI has booted up, along with signatures of these expected PCR 11 hash values, in the `.pcrsig` section. The signatures must also match the abovementioned key pair.
 * Optionally, a CSV file encoding the SBAT metadata for the image, in the `.sbat` section. The [SBAT format is defined by the Shim project](https://github.com/rhboot/shim/blob/main/SBAT.md), and used for UEFI revocation purposes.
+
+Note that all of the sections defined above are singletons: they may appear once at most – except for the `.dtb` section which may be appear more than once.
 
 ### JSON Format for `.pcrsig`
 The format is a single JSON object, encoded as a zero-terminated `UTF-8` string. Each name in the object


### PR DESCRIPTION
In connection with the discussion in [1] this pull request specifies how the case of multiple Device Trees is to be handled by choosing to append all additional Device Trees in the same .dtb section.

[1]: https://github.com/uapi-group/specifications/issues/66