### PR TITLE
specs/bls: fix relative links

### DIFF
--- a/specs/boot_loader_specification.md
+++ b/specs/boot_loader_specification.md
@@ -499,9 +499,9 @@ primary sorting key. Instead, the boot loader should use the following rules:
    are thus sorted earlier.
 
 2. If `sort-key` is set on both entries, use in order of priority,
-   the `sort-key` (A-Z, increasing [alphanumerical order](#alphanumerical-order)),
+   the `sort-key` (A-Z, increasing [alphanumerical order]({{< relref "#alphanumerical-order" >}})),
    `machine-id` (A-Z, increasing alphanumerical order),
-   and `version` keys (decreasing [version order](#version-order)).
+   and `version` keys (decreasing [version order]({{< relref "#version-order" >}})).
 
 3. If `sort-key` is set on one entry, it sorts earlier.
 


### PR DESCRIPTION
Fixes https://github.com/uapi-group/specifications/issues/63.

Quoting https://github.com/uapi-group/specifications/issues/63#issuecomment-1747361084:
> The portable links stuff was introduced in 4cd8de0, which also converted the
> relative links to their current form. Using relref[0] might be the easier way
> out here.
>
> [0] https://gohugo.io/content-management/cross-references/