### PR TITLE
DDI: change suffix to .gpt

### DIFF
--- a/specs/discoverable_disk_image.md
+++ b/specs/discoverable_disk_image.md
@@ -25,16 +25,18 @@ or 4096, as per GPT specification.
 
 ## Naming
 
-DDIs should use `.raw` as file suffix. A secondary suffix may be used to clarify the specific usage class of
-a DDI. For now the two secondary suffixes `.sysext.raw` and `.confext.raw` are defined (for system extension
-DDIs and configuration extension DDIs, see [Extension
-Images](https://uapi-group.org/specifications/specs/extension_image) for details).
+DDIs should use `.gpt` as file suffix.
+A secondary suffix may be used to clarify the specific usage class of a DDI.
+For now the two secondary suffixes `.sysext.gpt` and `.confext.gpt` are defined
+(for system extension DDIs and configuration extension DDIs, see
+[Extension Images](https://uapi-group.org/specifications/specs/extension_image)
+for details).
 
 The MIME type for DDIs is `application/vnd.efi.img`, [as per
 IANA](https://www.iana.org/assignments/media-types/application/vnd.efi.img).
 
 ## Image Version
 If the DDI is versioned, the version format described in the
-[Version Format Specification](version_format_specification.md) must be used. The underscore character (`_`)
-must be used to separate the version from the name of the image. For example: `foo_1.2.raw` denotes a `foo`
-DDI with version `1.2`.
+[Version Format Specification](version_format_specification.md) must be used.
+The underscore character (`_`) must be used to separate the version from the name of the image.
+For example: `foo_1.2.gpt` denotes a `foo` DDI with version `1.2`.

--- a/specs/extension_image.md
+++ b/specs/extension_image.md
@@ -39,9 +39,10 @@ Extension Images should be additive, and not override content present in the bas
 but this will not be enforced.
 
 ## File Suffix
-Since extensions images are DDIs, they should carry the `.raw` suffix. In order to make discerning system
-extensions and configuration extensions easy it is recommended to use the `.sysext.raw` suffix for system
-extensions, and `.confext.raw` for configuration extensions.
+Since extension images are DDIs, they should also carry the `.gpt` suffix.
+In order to make discerning system extensions and configuration extensions easy
+it is recommended to use the `.sysext.gpt` suffix for system extensions,
+and `.confext.gpt` for configuration extensions.
 
 ## Identification
 An Extension Image must contain a `extension-release.<IMAGE>` file, where `<IMAGE>` must either match the


### PR DESCRIPTION
Follow-up to 68dd1d96c359908cf494454af2b0ce1b9d4f9599: the extension ".raw" is not ideal:
- it is too generic: there are simply too many things which are "raw", and different people will have different expectations, and an extension should be unique.
- a DDI is not actually "raw". It has a header with a partition table, so it's a well-defined binary container format. "Raw" would normally be used for file with just contains unadorned data, without a header or other means of understanding the contents without context. Once you take the exact same data, but wrap a header around it that describes the data, the file contents are not "raw".

Semantic Line Breaks à la https://sembr.org/ are used.