### PR TITLE
Revert "LFSH: tone down text about shared ownership in /usr/share"

### DIFF
--- a/specs/linux_file_system_hierarchy.md
+++ b/specs/linux_file_system_hierarchy.md
@@ -223,9 +223,11 @@ such as documentation, man pages, time zone information, fonts and other resourc
 Usually, the precise location and format of files stored below this directory
 is subject to specifications that ensure interoperability.
 
-Note that resources placed in this directory may be under shared ownership,
-with multiple different packages providing and consuming these resources
-on equal footing without any obvious primary owner.
+Note that resources placed in this directory typically are under shared ownership,
+i.e. multiple different packages have provided and consumed these resources,
+on equal footing, without any obvious primary owner.
+This makes things systematically different from `/usr/lib/`,
+where ownership is generally not shared.
 
 ### `/usr/share/doc/`
 


### PR DESCRIPTION
This reverts commit 1f621b31e389c0d0519f1035a4e1e0fecf9617e4.

The reverted commit suggests that tmpfiles.d/ was a great example of shared ownership on equal footing, but that's simply not true, it's quite the contrary: the dir is owned a lot more by systemd-tmpfiles than by the packages dropping in files there, because the primary (and sole) consumer of those files is systemd-tmpfiles and – most importantly – the format is defined by systemd-tmpfiles and controlled by it, and by nothing else.

This creates an "imbalance of power" if you so will: one (singular) side defines and consumes, the other sides (plural) provide. And this is definitely not a "shared ownership on equal footing", it's quite the opposite.

And this to me is the fundamental difference that /usr/share/ vs /usr/lib/ really should be: resources in one are owned/controlled by some project in a fundamental way the other contains inherently shared resources, where *everyone* is on equal footing.