### PR TITLE
LFSH: clarify that systemd tools are not always available

### DIFF
--- a/specs/linux_file_system_hierarchy.md
+++ b/specs/linux_file_system_hierarchy.md
@@ -36,7 +36,7 @@ in the structure of an actually deployed OS.
 
 Many of the paths described here can be queried with the
 [`systemd-path(1)`](https://www.freedesktop.org/software/systemd/man/systemd-path.html)
-tool.
+tool, on systems where this tool is available.
 
 ## General Structure
 
@@ -224,14 +224,15 @@ This document does not mandate any specific choice.
 ### `/usr/lib/arch-id/`
 
 Location for placing dynamic libraries into, also called `$libdir`.
-The architecture identifier to use is defined on
+The architecture identifier to use is defined on the
 [Multiarch Architecture Specifiers (Tuples)](https://wiki.debian.org/Multiarch/Tuples)
 list.
 Legacy locations of `$libdir` are `/usr/lib/`, `/usr/lib64/`.
+
 This directory should not be used for package-specific data,
 unless this data is architecture-dependent, too.
 
-To query `$libdir` for the primary architecture of the system, invoke:
+The primary architecture of the system (`$libdir`) may be queried with:
 
     systemd-path system-library-arch
 
@@ -329,6 +330,7 @@ The root directory for device nodes.
 Usually, this directory is mounted as a `devtmpfs` instance,
 but might be of a different type in sandboxed/containerized setups.
 This directory is managed jointly by the kernel and
+a userspace component such as
 [`systemd-udevd(8)`](https://www.freedesktop.org/software/systemd/man/systemd-udevd.html),
 and should not be written to by other components.
 A number of special purpose virtual file systems might be mounted below this directory.


### PR DESCRIPTION
In https://lwn.net/Articles/1032947/#Comments the topic of whether the mention of systemd-path indicates that it is the normative way to query this path was heavily contested. The mention of the tool was originally added as a hint, since systemd-path is only optional. Add a few words to indicate that systemd-path is optional. (… when first mentioned. I don't think we want to repeat this every time.)

Similarly, systemd-udev or something else might be used to populate /dev, so reword as suggested in the LWN comments.