### PR TITLE
DDI: Add recomendation for LUKS encrypted partitions

### DIFF
--- a/specs/discoverable_disk_image.md
+++ b/specs/discoverable_disk_image.md
@@ -14,10 +14,17 @@ extensions, portable services, containers and more, and shall be protected by si
 into one.  They are designed to be composable and stackable, and provide security by default.
 
 ## Image Format
+
 The images use the GPT partition table verbatim, so it will not be redefined here. Each partition contains
 a standard Linux filesystem (e.g.: `erofs`), so again this will not be redefined here.
 The [DPS](discoverable_partitions_specification.md) defines the GUIDs to use and the format of the
-`dm-verity` signature partition's JSON content.
+`dm-verity` signature partition's JSON content. The [DPS](discoverable_partitions_specification.md)
+allows optional LUKS encryption for additional confidentiality. Note that LUKS encryption by default does not
+provide authentication or integrity protection[^1]. A LUKS encrypted partition should be protected by signed
+`dm-verity`.
+
+[^1]: LUKS2 supports authenticated encryption as an experimental feature.
+      See [cryptsetup(8) - Authenticated disk encryption](https://man.archlinux.org/man/cryptsetup.8#Authenticated_disk_encryption_(EXPERIMENTAL))
 
 It is recommended to use a sector size of 512 bytes or 4096 for DDIs. Software operating with DDIs should
 automatically derive the sector size used for a DDI by looking for the `EFI PART` magic string at offsets 512
@@ -34,6 +41,7 @@ The MIME type for DDIs is `application/vnd.efi.img`, [as per
 IANA](https://www.iana.org/assignments/media-types/application/vnd.efi.img).
 
 ## Image Version
+
 If the DDI is versioned, the version format described in the
 [Version Format Specification](version_format_specification.md) must be used. The underscore character (`_`)
 must be used to separate the version from the name of the image. For example: `foo_1.2.raw` denotes a `foo`


### PR DESCRIPTION
Add note clarifying LUKS encryption vs dm-verity protection to inform users not to confuse confidentiality with integrity and authenticity.

Addresses https://github.com/systemd/systemd/pull/38854#issuecomment-3281055110