### PR TITLE
bls: tighten rules on file system choice

### DIFF
--- a/specs/boot_loader_specification.md
+++ b/specs/boot_loader_specification.md
@@ -64,12 +64,14 @@ same disk. Instead of maintaining one boot partition per installed OS (as
 `/boot/` was traditionally handled), all installed OSes use the same place for
 boot loader menu entries._
 
-For systems where the firmware is able to read file systems directly, the ESP
-must — and the MBR boot and GPT XBOOTLDR partition should — be a file system
-readable by the firmware. For most systems this means VFAT (16 or 32 bit).
-Applications accessing both partitions should hence not assume that
-fancier file system features such as symlinks, hardlinks, access control or
-case sensitivity are supported.
+The GPT ESP, GPT XBOOTLDR or MBR boot partition must be of type VFAT (16 or 32 bit).
+
+Inode types other than directories and regular files are not allowed as part or contents of any of the paths
+defined by this specification, for security reasons. Specifically, if for some reason a file system type
+other than VFAT is used, and symlinks, device nodes, FIFOs or sockets are used in any paths listed here
+(regardless if as the terminal inode of a file system path, or in any prefix path), this should result in an
+error. Applications should not expect case sensitivity, and need to be able to deal with case insensitive
+behaviour of the file system.
 
 Note that the partitions described here are not the exclusive territory of this specification.
 This specification only defines semantics of the `/loader/entries/` directory
@@ -143,6 +145,8 @@ recommended. Such a nested setup complicates an implementation via direct
 the inner `autofs` will trigger the outer one. Mounting the two partitions via
 `autofs` is recommended because the simple VFAT file system has weak data
 integrity properties and should remain unmounted whenever possible.)
+
+From Linux, the file systems must be mounted with `MS_NOEXEC`, `MS_NODEV`, `MS_NOSUID`, `MS_NOSYMFOLLOW`.
 
 ## Boot Loader Entries
 


### PR DESCRIPTION
Let's just say ESP/XBOOTLDR has to be VFAT. Everything else is just pain, because it means we cannot share the dirs between OSes, systems and so on.

Moreover, it's a security issue to use more complex file systems, as these file systems come without integrity protection, i.e. they cannot be authenticated before parsing them, which makes it key to limit use to VFAT.

In systemd for example we'll never mount ESP/XBOOTLDR as anything else than VFAT for these reasons, and the spec should be clear about this. (well, once https://github.com/systemd/systemd/pull/39267 is merged that is)