### PR TITLE
Fix link to FDO spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ BookToC: false
   ([canonical online location](https://uapi-group.org/specifications/specs/boot_loader_specification/))
 * [Configuration Files Specification](specs/configuration_files_specification.md):
   Standardises default locations and environment variables for locating common files or base directories.
-  This is derived from, and extends, the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html),
+  This is derived from, and extends, the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir/latest/),
   to allow for separation between vendor and admin configuration files, drop-in files, and masking.
   ([canonical online location](https://uapi-group.org/specifications/specs/configuration_files_specification/))
 * [Discoverable Partitions Specification](specs/discoverable_partitions_specification.md):

--- a/specs/linux_file_system_hierarchy.md
+++ b/specs/linux_file_system_hierarchy.md
@@ -21,7 +21,7 @@ and includes concepts described in the
 specification and
 [`hier(7)`](https://man7.org/linux/man-pages/man7/hier.7.html) man page,
 and various extensions documented in the
-[XDG Base Directory Specification](https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html)
+[XDG Base Directory Specification](https://specifications.freedesktop.org/basedir/latest/)
 and [XDG User Directories](https://www.freedesktop.org/wiki/Software/xdg-user-dirs).
 
 In some areas this document is stricter than those older documents.
@@ -190,7 +190,7 @@ Always writable, flushed at each reboot and when the user logs out.
 User code should not reference this directory directly,
 but via the `$XDG_RUNTIME_DIR` environment variable,
 as documented in the
-[XDG Base Directory Specification](https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html).
+[XDG Base Directory Specification](https://specifications.freedesktop.org/basedir/latest/).
 
 ## Vendor-supplied Operating System Resources
 
@@ -508,7 +508,7 @@ in the user's home directory.
 They should follow the following basic structure.
 Note that some of these directories are also standardized
 (though more weakly) by the
-[XDG Base Directory Specification](https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html).
+[XDG Base Directory Specification](https://specifications.freedesktop.org/basedir/latest/).
 Additional locations for high-level user resources are defined by
 [xdg-user-dirs](https://www.freedesktop.org/wiki/Software/xdg-user-dirs).
 


### PR DESCRIPTION
The existing links are 404 as something changed on the website, update to new links