### PR TITLE
DPS: Reserve a couple of partition name prefixes for updates

### DIFF
--- a/specs/discoverable_partitions_specification.md
+++ b/specs/discoverable_partitions_specification.md
@@ -207,6 +207,11 @@ For details about the version format see the
 [Version Format Specification](version_format_specification.md). The underscore
 character (`_`) must be used to separate the version from the name of the image.
 
+For operating systems which update partitions in two or more stages, names prefixed
+with `PRT#` or `PND#` are reserved for indicating that a partition is partially
+updated or is pending being swapped into use. Tools other than the updater
+operating on such partitions should typically ignore them.
+
 ## Partition Attribute Flags
 
 This specification defines three GPT partition attribute flags that may be set


### PR DESCRIPTION
systemd-sysupdate is gaining support for downloading and applying updates as separate stages. In order to do this, it needs to be able to stage pending or partially applied updates in partitions, and is doing so with a prefix on the partition name.

See https://github.com/systemd/systemd/pull/40236 (and in particular https://github.com/systemd/systemd/pull/40236#pullrequestreview-3746347344).

Document that prefix so it can be standardised across tooling.