### PR TITLE
ELF dlopen metadata: Mention systemd-analyze dlopen-metadata

### DIFF
--- a/specs/elf_dlopen_metadata.md
+++ b/specs/elf_dlopen_metadata.md
@@ -125,7 +125,16 @@ Contents of section .note.dlopen:
 ...
 ```
 
-It is more convenient to use a higher level tool:
+For a quick look it is more convenient to use `systemd-analyze dlopen-metadata`:
+```console
+$ systemd-analyze dlopen-metadata /usr/lib64/libsystemd.so.0
+FEATURE DESCRIPTION                                            SONAME       PRIORITY   
+lzma    Support lzma compression in journal and coredump files liblzma.so.5 suggested
+lz4     Support lz4 compression in journal and coredump files  liblz4.so.1  suggested
+zstd    Support zstd compression in journal and coredump files libzstd.so.1 recommended
+```
+
+Another higher level tool is `dlopen-notes`:
 ```console
 $ dlopen-notes /usr/lib64/systemd/libsystemd-shared-257.so
 # /usr/lib64/systemd/libsystemd-shared-257.so


### PR DESCRIPTION
As a high-level tool that's likely preinstalled systemd-analyze dlopen-metadata was missing. Add it as first recommendation for a high-level tool after the objdump JSON dump command.