### PR TITLE
Add UAPI.18: CLI introspection

### DIFF
--- a/specs/cli_introspection.md
+++ b/specs/cli_introspection.md
@@ -274,15 +274,27 @@ either to a positional argument or an optional argument.
 }
 ```
 
-All keys except `type` and one of `value`, `dynamic` or `missing` are optional
-and are treated as empty string or false when missing.
+All keys except `type` and one of `value`, `category`, `dynamic` or `missing`
+are optional and are treated as empty string or false when missing.
 
 `type` is the fixed string `value` and signals that this is a value object,
 describing an argument value.
 
-`value` is a string describing a possible value.
+`value` is a string describing a possible static value.
 
-`dynamic` is a non-empty array of strings describing a sequence of commands,
+`category` is a string describing a category of values:
+- `path`, any filesystem path,
+- `file`, a filesystem path to a regular file,
+- `dir`, a filesystem path to a directory,
+- `pid`, a PID,
+- `uid`, a numeric UID,
+- `gid`, a numeric GID,
+- `username`, a user's name,
+- `groupname`, a group's name,
+- `hostname`, a hosts' name, and
+- `unit`, a systemd unit's name.
+
+`dynamic` is a non-empty string describing a commands,
 that can be called to generate multiple values.
 This is relevant for the dynamic generation of completion candidates during
 command line completion.

--- a/specs/cli_introspection.md
+++ b/specs/cli_introspection.md
@@ -148,6 +148,7 @@ Value objects describe a value that is passed as an argument, either to a
     "help": "help text",
     "default": True
 }
+```
 
 All keys except `name` are optional and are treated as empty string or false
 when missing.

--- a/specs/cli_introspection.md
+++ b/specs/cli_introspection.md
@@ -69,7 +69,7 @@ The command object is recursively defined as follows.
     "options": [<option object>, …],
     "verbs": [<command >, …],
     "documentation": ["doc1", …],
-    "package": "myproject"
+    "project": "myproject"
 }
 ```
 
@@ -102,7 +102,7 @@ that should not be larger than 16.
 `documentation` is an array of string values describing URIs referencing
 documentation for this command, see `man:uri(7)`for a description of valid URIs.
 
-`package` is a string describing what this command belongs to. This may the
+`project` is a string describing what this command belongs to. This may the
 package that installed it or the project that produced it.
 
 ### Argspec objects

--- a/specs/cli_introspection.md
+++ b/specs/cli_introspection.md
@@ -272,18 +272,36 @@ either to a positional argument or an optional argument.
 }
 ```
 
-All keys except `type` and `name` are optional and are treated as empty string
-or false when missing.
+All keys except `type` and one of `value`, `dynamic` or `missing` are optional
+and are treated as empty string or false when missing.
 
 `type` is the fixed string `value` and signals that this is a value object,
 describing an argument value.
 
 `value` is a string describing a possible value.
 
+`dynamic` is a non-empty array of strings describing a sequence of commands,
+that can be called to generate multiple values.
+This is relevant for the dynamic generation of completion candidates during
+command line completion.
+The current input for the argument,
+if any otherwise an empty string,
+will be passed as first and only argument to the first element of the array and
+its standard output stream will be passed as input stream to the next element
+and so on with the standard output stream of the last element defining the
+values,
+one per line.
+
+`missing` is a boolean signalling that some values are missing from the
+description.
+
 `help` is a string describing the help text that should be shown for the value.
 
 `default` is a boolean describing whether this value is the default value for
 the option this is a value for.
+
+If multiple of `value`, `dynamic` and `missing` are defined,
+`missing` has the highest precedence, followed by `value` and `dynamic`.
 
 ## Example
 

--- a/specs/cli_introspection.md
+++ b/specs/cli_introspection.md
@@ -67,7 +67,7 @@ The command object is recursively defined as follows.
     "abstract": ["paragraph1", "paragraph2", …],
     "postscript": ["paragraph1", "paragraph2", …],
     "options": [<option object>, …],
-    "verbs" : [<command >, …]
+    "verbs": [<command >, …]
 }
 ```
 

--- a/specs/cli_introspection.md
+++ b/specs/cli_introspection.md
@@ -67,7 +67,8 @@ The command object is recursively defined as follows.
     "abstract": ["paragraph1", "paragraph2", …],
     "postscript": ["paragraph1", "paragraph2", …],
     "options": [<option object>, …],
-    "verbs": [<command >, …]
+    "verbs": [<command >, …],
+    "documentation": ["doc1", …]
 }
 ```
 
@@ -96,6 +97,9 @@ arrays may be empty. Each element of the array represents a paragraph of text.
 `verbs` are command objects that describe a program's verbs, also called
 subcommands. Verbs may recursively define further verbs up to a maximum depth
 that should not be larger than 16.
+
+`documentation` is an array of string values describing URIs referencing
+documentation for this command, see `man:uri(7)`for a description of valid URIs.
 
 ### Argspec objects
 

--- a/specs/cli_introspection.md
+++ b/specs/cli_introspection.md
@@ -287,11 +287,9 @@ that can be called to generate multiple values.
 This is relevant for the dynamic generation of completion candidates during
 command line completion.
 The current input for the argument,
-if any otherwise an empty string,
-will be passed as first and only argument to the first element of the array and
-its standard output stream will be passed as input stream to the next element
-and so on with the standard output stream of the last element defining the
-values,
+if any,
+otherwise an empty string will be passed as first and only argument.
+The standard output stream of the command defines the values,
 one per line.
 
 `missing` is a boolean signalling that some values are missing from the

--- a/specs/cli_introspection.md
+++ b/specs/cli_introspection.md
@@ -165,7 +165,10 @@ long-options. Short options are usually followed by a single chracters, whereas
 long options can be a longer string. Short otions may be followed by multiple
 characters, but this is discouraged.
 
-`argument` defines the argument type TODO
+`argument` defines the argument type, which is one of the strings:
+-`no_argument`,
+-`required_argument`, or
+-`optional_argument`.
 
 `help` is a string that defines the help text of the option.
 
@@ -187,7 +190,7 @@ Value objects describe a value that is passed as an argument, either to a
 {
     "name": "myname",
     "help": "help text",
-    "default": True
+    "default": true
 }
 ```
 

--- a/specs/cli_introspection.md
+++ b/specs/cli_introspection.md
@@ -36,13 +36,13 @@ The schema is defines as
 
 ```json
 {
-    "mediaType" : "application/vnd.io.systemd.cli-introspection-0",
+    "mediaType" : "application/vnd.uapi-group.cli-introspection-0",
     "commands": [<command object>, …]
 }
 ```
 
 where `mediaType` is the fixed string
-`application/vnd.io.systemd.cli-introspection-0` and `commands` is a non-empty
+`application/vnd.uapi-group.cli-introspection-0` and `commands` is a non-empty
 JSON array of *command objects*.
 
 Further additions to this specification will only be additive and non-backwards

--- a/specs/cli_introspection.md
+++ b/specs/cli_introspection.md
@@ -194,7 +194,8 @@ This is only for display-purposes.
 
 `values` is an array of *value objects* describing the values this option may
 take.
-An empty array describes an argument that is a single arbitrary word.
+An empty array describes an argument that is a single arbitrary word with no
+further documented semantic.
 Value objects are described in a section below.
 
 `isDeprecated` is a boolean describing whether this option has been deprecated.
@@ -252,7 +253,8 @@ This is only for display-purposes.
 
 `values` is an array of *value objects* describing the values this option may
 take.
-An empty array describes an argument that is a single arbitrary word.
+An empty array describes an argument that is a single arbitrary word with no
+further documented semantic.
 Value objects are described in a section below.
 
 `isDeprecated` is a boolean describing whether this option has been deprecated.

--- a/specs/cli_introspection.md
+++ b/specs/cli_introspection.md
@@ -69,7 +69,7 @@ The command object is recursively defined as follows.
     "options": [<option object>, …],
     "verbs": [<command >, …],
     "documentation": ["doc1", …],
-    `package`: "myproject"
+    "package": "myproject"
 }
 ```
 

--- a/specs/cli_introspection.md
+++ b/specs/cli_introspection.md
@@ -156,7 +156,8 @@ explicitly made.
     "help": "Show this help",
     "group": [""],
     "conflicts": [],
-    "values": [<value object>]
+    "values": [<value object>],
+    "section": "option block 1"
 }
 ```
 
@@ -188,6 +189,8 @@ this option may not be called together with.
 
 `values` is an array of *value objects* describing the values this option may
 take. Value objects are described in a section below.
+
+`section` is a string to visually group options into separate lists.
 
 ### Value objects
 

--- a/specs/cli_introspection.md
+++ b/specs/cli_introspection.md
@@ -70,6 +70,7 @@ The command object is recursively defined as follows.
     "features": ["feature1", "feature2", …]
     "abstract": ["paragraph1", "paragraph2", …],
     "postscript": ["paragraph1", "paragraph2", …],
+    "help": "short help"
     "options": [<option object>, …],
     "verbs": [<command >, …],
     "documentation": ["doc1", …],
@@ -97,6 +98,10 @@ program.
 `abstract` and `postscript` define arrays of strings that are shown respectively
 before and after the description of options in the program's help output. Each
 element of the array represents a paragraph of text.
+
+`help` defines the help text of the command. This is useful for single-line
+usage information as well as for short descriptions of verbs in the list of
+options.
 
 `options` define a CLI's positional arguments and options and are described in a section below.
 

--- a/specs/cli_introspection.md
+++ b/specs/cli_introspection.md
@@ -85,7 +85,7 @@ builtin-in features of this program.
 
 `abstract` and `postscript` define arrays of strings that are shown respectively
 before and after the description of options in the program's help output. These
-arrays may be empty.
+arrays may be empty. Each element of the array represents a paragraph of text.
 
 `options` define a program's arguments and options and are described in a section below.
 

--- a/specs/cli_introspection.md
+++ b/specs/cli_introspection.md
@@ -68,7 +68,8 @@ The command object is recursively defined as follows.
     "postscript": ["paragraph1", "paragraph2", …],
     "options": [<option object>, …],
     "verbs": [<command >, …],
-    "documentation": ["doc1", …]
+    "documentation": ["doc1", …],
+    `package`: "myproject"
 }
 ```
 
@@ -100,6 +101,9 @@ that should not be larger than 16.
 
 `documentation` is an array of string values describing URIs referencing
 documentation for this command, see `man:uri(7)`for a description of valid URIs.
+
+`package` is a string describing what this command belongs to. This may the
+package that installed it or the project that produced it.
 
 ### Argspec objects
 

--- a/specs/cli_introspection.md
+++ b/specs/cli_introspection.md
@@ -64,7 +64,7 @@ The command object is recursively defined as follows.
     "version": "myversion",
     "features": ["feature1", "feature2", …]
     "abstract": ["paragraph1", "paragraph2", …],
-    "footer": ["paragraph1", "paragraph2", …],
+    "postscript": ["paragraph1", "paragraph2", …],
     "options": [<option object>, …],
     "verbs" : [<command >, …]
 }
@@ -83,7 +83,7 @@ UAPI.10 Version Format Specification-compatible.
 `features` defines an array of strings, that can be empty, that define
 builtin-in features of this program.
 
-`abstract` and `footer` define arrays of strings that are shown respectively
+`abstract` and `postscript` define arrays of strings that are shown respectively
 before and after the description of options in the program's help output. These
 arrays may be empty.
 

--- a/specs/cli_introspection.md
+++ b/specs/cli_introspection.md
@@ -61,6 +61,7 @@ The command object is recursively defined as follows.
 ```json
 {
     "names" : ["name1", "name2", …],
+    "argspec": ["value1", "value2", …]
     "version": "myversion",
     "features": ["feature1", "feature2", …]
     "abstract": ["paragraph1", "paragraph2", …],
@@ -77,6 +78,9 @@ array when missing.
 of that array is the primary name of that command. Further names can be added as
 aliases, e.g. for backwards-compatibility.
 
+`argspec` is an array of argspec objects describing the arguments to the command
+after the name of the command, i.e. `argv` excluding the element with index 0.
+
 `version` defines the version string of the program. This string should be a
 UAPI.10 Version Format Specification-compatible.
 
@@ -92,6 +96,43 @@ arrays may be empty. Each element of the array represents a paragraph of text.
 `verbs` are command objects that describe a program's verbs, also called
 subcommands. Verbs may recursively define further verbs up to a maximum depth
 that should not be larger than 16.
+
+### Argspec objects
+
+Argspec objects describe the arguments passed to the program, specifically in
+what order arguments, verbs and options are passed to the program.
+
+```json
+{
+    "name": "myname",
+    "metavar": "METAVAR",
+    "type": "argument",
+    "optional": true,
+    "default": null
+}
+```
+
+All keys except `name` and `type` are required and are treated as empty string,
+false or null if missing.
+
+`name` is a non-empty string describing the internal name of a value.
+
+`metavar` is a string describing the name that is shown in the argspec of the
+command. If it is empty, it defaults to the value of `name`.
+
+`type` is a string describing what the argument is. It is either of
+- `argument`, a direct argument to the command,
+- `option`, which is an option from the `options` array of a command, or
+- `verb`, which is a verb from the `verbs` array of a command.
+
+`optional` is a boolean describing whether an argspec object of type `argument`
+or `verb` must be passed or not. `optional` is ignored for argspec objects of
+type `option`.
+
+`default` is a string or null describing what the default value for this
+argument is. `null`, the default, means there is no default. `default` is
+ignored for argspec objects of type `option`. For argspec objects of type `verb`
+a non-`null` value must be a `name` of a commands object in the verbs array.
 
 ### Option objects
 

--- a/specs/cli_introspection.md
+++ b/specs/cli_introspection.md
@@ -73,7 +73,8 @@ The command object is recursively defined as follows.
     "options": [<option object>, …],
     "verbs": [<command >, …],
     "documentation": ["doc1", …],
-    "project": "myproject"
+    "project": "myproject",
+    "isDeprecated": false
 }
 ```
 
@@ -110,6 +111,8 @@ widely supported in modern terminals.
 
 `project` is a string describing what this command belongs to. This may the
 package that installed it or the project that produced it.
+
+`isDeprecated` is a boolean describing whether the command has been
 
 ### Argspec objects
 
@@ -162,7 +165,8 @@ explicitly made.
     "help": "Show this help",
     "group": [""],
     "values": [<value object>],
-    "section": "option block 1"
+    "section": "option block 1",
+    "isDeprecated": false
 }
 ```
 
@@ -194,6 +198,8 @@ take. Value objects are described in a section below.
 
 `section` is a string to visually group options into separate lists.
 
+`isDeprecated` is a boolean describing whether this option has been deprecated.
+
 ### Value objects
 
 Value objects describe a value that is passed as an argument, either to a
@@ -203,7 +209,8 @@ Value objects describe a value that is passed as an argument, either to a
 {
     "name": "myname",
     "help": "help text",
-    "default": true
+    "default": true,
+    "isDeprecated": false
 }
 ```
 

--- a/specs/cli_introspection.md
+++ b/specs/cli_introspection.md
@@ -1,0 +1,160 @@
+---
+title: UAPI.X CLI-Introspection Specification
+category: Booting
+layout: default
+version: 0.0
+SPDX-License-Identifier: CC-BY-4.0
+weight: 1
+aliases:
+- /UAPI.X
+- /X
+---
+
+# UAPI.X The CLI-Introspection Specification
+
+| Version | Changes |
+|---------|---------|
+| 0.0     | WIP     |
+
+This document defines a JSON schema defining a machine-readable equivalent of
+what programs commonly output when they are called with the `--help` or an
+equivalent option.
+
+This output can be used, among other things, to check whether a program has a
+given option or to automatically generate command-line completion for different
+shells.
+
+## Target Audience
+
+The target audience for this specification are:
+
+* People writing runnable programs that have command-line interfaces.
+
+## The Schema
+
+The schema is defines as
+
+```json
+{
+    "mediaType" : "application/vnd.io.systemd.cli-introspection-0",
+    "commands": [<command object>, …]
+}
+```
+
+where `mediaType` is the fixed string
+`application/vnd.io.systemd.cli-introspection-0` and `commands` is a non-empty
+JSON array of *command objects*.
+
+Further additions to this specification will only be additive and non-backwards
+compatible changes may only be introduced by defining a new `mediaType`.
+
+The `commands` array defines the actual CLI and a single binary can define
+arbitrarily many CLIs, but must define at least one. Defining multiple CLIs is
+relevant for multicall binaries that behave differently depending on with what
+name they are called, e.g `argv[0]` or in the context of scripting languages
+under what name they are imported
+
+### Command ojects
+
+The command object is recursively defined as follows.
+
+```json
+{
+    "names" : ["name1", "name2", …],
+    "version": "myversion",
+    "features": ["feature1", "feature2", …]
+    "abstract": ["paragraph1", "paragraph2", …],
+    "footer": ["paragraph1", "paragraph2", …],
+    "options": [<option object>, …],
+    "verbs" : [<command >, …]
+}
+```
+
+All keys except `names` are optional and are treated as empty string or empty
+array when missing.
+
+`names` is a non-empty array of string names for that command. The first element
+of that array is the primary name of that command. Further names can be added as
+aliases, e.g. for backwards-compatibility.
+
+`version` defines the version string of the program. This string should be a
+UAPI.10 Version Format Specification-compatible.
+
+`features` defines an array of strings, that can be empty, that define
+builtin-in features of this program.
+
+`abstract` and `footer` define arrays of strings that are shown respectively
+before and after the description of options in the program's help output. These
+arrays may be empty.
+
+`options` define a program's arguments and options and are described in a section below.
+
+`verbs` are command objects that describe a program's verbs, also called
+subcommands. Verbs may recursively define further verbs up to a maximum depth
+that should not be larger than 16.
+
+### Option objects
+
+Option objects arguments define both (positional)arguments as well as options
+(commonly prefixed with `-` or `--`) of a program. Both arguments and options
+will be referred to as options in this section, when a distinction is not
+explicitly made.
+
+```json
+{
+    "names": ["-h","--help"],
+    "argument": "no_argument",
+    "help": "Show this help",
+    "group": [""],
+    "conflicts": [],
+    "values": [<value object>]
+}
+```
+
+All keys except `names` and `argument` are optional and are treated as empty
+string or empty array when missing.
+
+`names` is a non-empty array of strings defining the name of an option. Names
+starting with dashes define options and names not starting with dashes define
+(positional) arguments. An option object may define only options or arguments,
+but not both for the same object, i.e. an option object may not have names both
+with and without dashes. Options prefixed with a single dash (`-`) are called
+short options and options prefixed with two dashes (`--`) are called
+long-options. Short options are usually followed by a single chracters, whereas
+long options can be a longer string. Short otions may be followed by multiple
+characters, but this is discouraged.
+
+`argument` defines the argument type TODO
+
+`help` is a string that defines the help text of the option.
+
+`group` is an array of string that defines sections in which this option should
+be shown. This is only for display-purposes.
+
+`conflicts` defines an array of strings referring to the names of other options
+this option may not be called together with.
+
+`values` is an array of *value objects* describing the values this option may
+take. Value objects are described in a section below.
+
+### Value objects
+
+Value objects describe a value that is passed as an argument, either to a
+(positional) argument or an option.
+
+```json
+{
+    "name": "myname",
+    "help": "help text",
+    "default": True
+}
+
+All keys except `name` are optional and are treated as empty string or false
+when missing.
+
+`name` is a string describing the name of a value.
+
+`help` is a string describing the help text that should be shown for an option.
+
+`default` is a boolean describing whether this value is the default value for
+the option this is a value for.

--- a/specs/cli_introspection.md
+++ b/specs/cli_introspection.md
@@ -1,13 +1,13 @@
 ---
 title: UAPI.X CLI-Introspection Specification
-category: Booting
+category: Interfaces
 layout: default
 version: 0.0
 SPDX-License-Identifier: CC-BY-4.0
 weight: 1
 aliases:
-- /UAPI.X
-- /X
+- /UAPI.18
+- /18
 ---
 
 # UAPI.X The CLI-Introspection Specification
@@ -28,15 +28,18 @@ shells.
 
 The target audience for this specification are:
 
-* People writing runnable programs that have command-line interfaces.
+* People writing runnable programs that have command-line interfaces,
+* authors of tab-completion helpers, and
+* people interested in automatic testing of documentation and self-documenting
+  interfaces.
 
 ## The Schema
 
-The schema is defines as
+The schema is defined as
 
 ```json
 {
-    "mediaType" : "application/vnd.uapi-group.cli-introspection-0",
+    "mediaType" : "application/vnd.uapi-group.cli-introspection",
     "commands": [<command object>, …]
 }
 ```
@@ -45,14 +48,15 @@ where `mediaType` is the fixed string
 `application/vnd.uapi-group.cli-introspection-0` and `commands` is a non-empty
 JSON array of *command objects*.
 
-Further additions to this specification will only be additive and non-backwards
+Further additions to this specification will only be additive and non-backward
 compatible changes may only be introduced by defining a new `mediaType`.
 
 The `commands` array defines the actual CLI and a single binary can define
 arbitrarily many CLIs, but must define at least one. Defining multiple CLIs is
 relevant for multicall binaries that behave differently depending on with what
-name they are called, e.g `argv[0]` or in the context of scripting languages
-under what name they are imported
+name they are called, e.g the basename of `argv[0]`,
+`program_invocation_short_name` in the GNU system context, or in the context of
+scripting languages the name under which they are imported
 
 ### Command ojects
 
@@ -78,29 +82,31 @@ array when missing.
 
 `names` is a non-empty array of string names for that command. The first element
 of that array is the primary name of that command. Further names can be added as
-aliases, e.g. for backwards-compatibility.
+aliases, e.g. for backward compatibility.
 
 `argspec` is an array of argspec objects describing the arguments to the command
-after the name of the command, i.e. `argv` excluding the element with index 0.
+after the name of the command, i.e. C language `argv` excluding the element with index 0.
 
-`version` defines the version string of the program. This string should be a
-UAPI.10 Version Format Specification-compatible.
+`version` defines the version string of the program. This string should be string compatible
+with UAPI.10 Version Format Specification-compatible.
 
-`features` defines an array of strings, that can be empty, that define
-builtin-in features of this program.
+`features` defines an array of strings that define builtin-in features of this
+program.
 
 `abstract` and `postscript` define arrays of strings that are shown respectively
-before and after the description of options in the program's help output. These
-arrays may be empty. Each element of the array represents a paragraph of text.
+before and after the description of options in the program's help output. Each
+element of the array represents a paragraph of text.
 
-`options` define a program's arguments and options and are described in a section below.
+`options` define a CLI's positional arguments and options and are described in a section below.
 
 `verbs` are command objects that describe a program's verbs, also called
 subcommands. Verbs may recursively define further verbs up to a maximum depth
 that should not be larger than 16.
 
 `documentation` is an array of string values describing URIs referencing
-documentation for this command, see `man:uri(7)`for a description of valid URIs.
+documentation for this command, see `man:uri(7)`for a description of valid
+URIs. Preferably the URIs should be URLs starting with `https://` as these are
+widely supported in modern terminals.
 
 `project` is a string describing what this command belongs to. This may the
 package that installed it or the project that produced it.
@@ -108,12 +114,12 @@ package that installed it or the project that produced it.
 ### Argspec objects
 
 Argspec objects describe the arguments passed to the program, specifically in
-what order arguments, verbs and options are passed to the program.
+what order verbs, arguments, and options are passed to the program.
 
 ```json
 {
     "name": "myname",
-    "metavar": "METAVAR",
+    "value_name": "VALUE_NAME",
     "type": "argument",
     "optional": true,
     "default": null
@@ -125,17 +131,17 @@ false or null if missing.
 
 `name` is a non-empty string describing the internal name of a value.
 
-`metavar` is a string describing the name that is shown in the argspec of the
-command. If it is empty, it defaults to the value of `name`.
+`value_name` is a string describing the name that is shown in the argspec of the
+command. If it is empty, it defaults to the value of `name`. This concept is
+sometimes also called metavar.
 
 `type` is a string describing what the argument is. It is either of
-- `argument`, a direct argument to the command,
-- `option`, which is an option from the `options` array of a command, or
+- `argument`, a positional argument to the command,
+- `option`, which is command line switch from the `options` array of a command, or
 - `verb`, which is a verb from the `verbs` array of a command.
 
 `optional` is a boolean describing whether an argspec object of type `argument`
-or `verb` must be passed or not. `optional` is ignored for argspec objects of
-type `option`.
+or `verb` must be passed or not.
 
 `default` is a string or null describing what the default value for this
 argument is. `null`, the default, means there is no default. `default` is
@@ -144,7 +150,7 @@ a non-`null` value must be a `name` of a commands object in the verbs array.
 
 ### Option objects
 
-Option objects arguments define both (positional)arguments as well as options
+Option objects arguments define both (positional) arguments as well as options
 (commonly prefixed with `-` or `--`) of a program. Both arguments and options
 will be referred to as options in this section, when a distinction is not
 explicitly made.
@@ -155,22 +161,21 @@ explicitly made.
     "argument": "no_argument",
     "help": "Show this help",
     "group": [""],
-    "conflicts": [],
     "values": [<value object>],
     "section": "option block 1"
 }
 ```
 
 All keys except `names` and `argument` are optional and are treated as empty
-string or empty array when missing.
+when missing.
 
 `names` is a non-empty array of strings defining the name of an option. Names
 starting with dashes define options and names not starting with dashes define
-(positional) arguments. An option object may define only options or arguments,
+positional arguments. An option object may define only options or arguments,
 but not both for the same object, i.e. an option object may not have names both
 with and without dashes. Options prefixed with a single dash (`-`) are called
 short options and options prefixed with two dashes (`--`) are called
-long-options. Short options are usually followed by a single chracters, whereas
+long options. Short options are usually followed by a single chracters, whereas
 long options can be a longer string. Short otions may be followed by multiple
 characters, but this is discouraged.
 
@@ -183,9 +188,6 @@ characters, but this is discouraged.
 
 `group` is an array of string that defines sections in which this option should
 be shown. This is only for display-purposes.
-
-`conflicts` defines an array of strings referring to the names of other options
-this option may not be called together with.
 
 `values` is an array of *value objects* describing the values this option may
 take. Value objects are described in a section below.
@@ -210,7 +212,7 @@ when missing.
 
 `name` is a string describing the name of a value.
 
-`help` is a string describing the help text that should be shown for an option.
+`help` is a string describing the help text that should be shown for the value.
 
 `default` is a boolean describing whether this value is the default value for
 the option this is a value for.

--- a/specs/cli_introspection.md
+++ b/specs/cli_introspection.md
@@ -20,9 +20,10 @@ This document defines a JSON schema defining a machine-readable equivalent of
 what programs commonly output when they are called with the `--help` or an
 equivalent option.
 
-This output can be used, among other things, to check whether a program has a
-given option or to automatically generate command-line completion for different
-shells.
+This output can be used,
+among other things,
+to check whether a program has a given option or to automatically generate
+command-line completion for different shells.
 
 ## Target Audience
 
@@ -52,11 +53,14 @@ Further additions to this specification will only be additive and non-backward
 compatible changes may only be introduced by defining a new `mediaType`.
 
 The `commands` array defines the actual CLI and a single binary can define
-arbitrarily many CLIs, but must define at least one. Defining multiple CLIs is
-relevant for multicall binaries that behave differently depending on with what
-name they are called, e.g the basename of `argv[0]`,
-`program_invocation_short_name` in the GNU system context, or in the context of
-scripting languages the name under which they are imported
+arbitrarily many CLIs,
+but must define at least one.
+Defining multiple CLIs is relevant for multicall binaries that behave
+differently depending on with what name they are called,
+e.g the basename of `argv[0]`,
+`program_invocation_short_name` in the GNU system
+context,
+or in the context of scripting languages the name under which they are imported
 
 ### Command ojects
 
@@ -82,47 +86,57 @@ The command object is recursively defined as follows.
 All keys except `names` are optional and are treated as empty string or empty
 array when missing.
 
-`names` is a non-empty array of string names for that command. The first element
-of that array is the primary name of that command. Further names can be added as
-aliases, e.g. for backward compatibility.
+`names` is a non-empty array of string names for that command.
+The first element of that array is the primary name of that command.
+Further names can be added as aliases,
+e.g. for backward compatibility.
 
 `argspec` is an array of argspec objects describing the arguments to the command
-after the name of the command, i.e. C language `argv` excluding the element with index 0.
+after the name of the command,
+i.e. C language `argv` excluding the element with index 0.
 
-`version` defines the version string of the program. This string should be string compatible
-with UAPI.10 Version Format Specification-compatible.
+`version` defines the version string of the program.
+This string should be string compatible with UAPI.10 Version Format
+Specification-compatible.
 
 `features` defines an array of strings that define builtin-in features of this
 program.
 
 `abstract` and `postscript` define arrays of strings that are shown respectively
-before and after the description of options in the program's help output. Each
-element of the array represents a paragraph of text.
+before and after the description of options in the program's help output.
+Each element of the array represents a paragraph of text.
+Both are meant for standalone help output, e.g. for the top-level help output of
+a program or specific help output of a verb in cases where they have their own
+help output.
 
 `help` defines the help text of the command. This is useful for single-line
 usage information as well as for short descriptions of verbs in the list of
 options.
 
-`options` define a CLI's positional arguments and options and are described in a section below.
+`options` define a CLI's positional arguments and options and are described in a
+section below.
 
-`verbs` are command objects that describe a program's verbs, also called
-subcommands. Verbs may recursively define further verbs up to a maximum depth
-that should not be larger than 16.
+`verbs` are command objects that describe a program's verbs,
+also called subcommands.
+Verbs may recursively define further verbs up to a maximum depth that should not
+be larger than 16.
 
 `documentation` is an array of string values describing URIs referencing
-documentation for this command, see `man:uri(7)`for a description of valid
-URIs. Preferably the URIs should be URLs starting with `https://` as these are
-widely supported in modern terminals.
+documentation for this command,
+see `man:uri(7)`for a description of valid URIs.
+Preferably the URIs should be URLs starting with `https://` as these are widely
+supported in modern terminals.
 
-`project` is a string describing what this command belongs to. This may the
-package that installed it or the project that produced it.
+`project` is a string describing what this command belongs to.
+This may the package that installed it or the project that produced it.
 
 `isDeprecated` is a boolean describing whether the command has been
 
 ### Argspec objects
 
-Argspec objects describe the arguments passed to the program, specifically in
-what order verbs, arguments, and options are passed to the program.
+Argspec objects describe the arguments passed to the program,
+specifically in what order verbs, arguments, and options are passed to the
+program.
 
 ```json
 {
@@ -140,8 +154,9 @@ false or null if missing.
 `name` is a non-empty string describing the internal name of a value.
 
 `value_name` is a string describing the name that is shown in the argspec of the
-command. If it is empty, it defaults to the value of `name`. This concept is
-sometimes also called metavar.
+command.
+If it is empty, it defaults to the value of `name`.
+This concept is sometimes also called metavar.
 
 `type` is a string describing what the argument is. It is either of
 - `argument`, a positional argument to the command,
@@ -151,17 +166,21 @@ sometimes also called metavar.
 `optional` is a boolean describing whether an argspec object of type `argument`
 or `verb` must be passed or not.
 
-`default` is a string or null describing what the default value for this
-argument is. `null`, the default, means there is no default. `default` is
-ignored for argspec objects of type `option`. For argspec objects of type `verb`
-a non-`null` value must be a `name` of a commands object in the verbs array.
+`default` is a string or null,
+describing what the default value for this argument is.
+`null`, the default, means there is no default.
+`default` is ignored for argspec objects of type `option`.
+For argspec objects of type `verb` a non-`null` value must be a `name` of a
+commands object in the verbs array.
 
 ### Option objects
 
-Option objects arguments define both (positional) arguments as well as options
-(commonly prefixed with `-` or `--`) of a program. Both arguments and options
-will be referred to as options in this section, when a distinction is not
-explicitly made.
+Option objects arguments define both positional arguments as well as options,
+commonly prefixed with `-` or `--`,
+of a program.
+Both positional arguments and options will be referred to as options in this
+section,
+when a distinction is not explicitly made.
 
 ```json
 {
@@ -178,15 +197,18 @@ explicitly made.
 All keys except `names` and `argument` are optional and are treated as empty
 when missing.
 
-`names` is a non-empty array of strings defining the name of an option. Names
-starting with dashes define options and names not starting with dashes define
-positional arguments. An option object may define only options or arguments,
-but not both for the same object, i.e. an option object may not have names both
-with and without dashes. Options prefixed with a single dash (`-`) are called
-short options and options prefixed with two dashes (`--`) are called
-long options. Short options are usually followed by a single chracters, whereas
-long options can be a longer string. Short otions may be followed by multiple
-characters, but this is discouraged.
+`names` is a non-empty array of strings defining the name of an option.
+Names starting with dashes define options and names not starting with dashes
+define positional arguments.
+An option object may define only options or arguments,
+but not both for the same object,
+i.e. an option object may not have names both with and without dashes.
+Options prefixed with a single dash (`-`) are called short options and options
+prefixed with two dashes (`--`) are called long options.
+Short options are usually followed by a single chracters,
+whereas long options can be a longer string.
+Short otions may be followed by multiple characters,
+but this is discouraged.
 
 `argument` defines the argument type, which is one of the strings:
 -`no_argument`,
@@ -196,10 +218,12 @@ characters, but this is discouraged.
 `help` is a string that defines the help text of the option.
 
 `group` is an array of string that defines sections in which this option should
-be shown. This is only for display-purposes.
+be shown.
+This is only for display-purposes.
 
 `values` is an array of *value objects* describing the values this option may
-take. Value objects are described in a section below.
+take.
+Value objects are described in a section below.
 
 `section` is a string to visually group options into separate lists.
 
@@ -207,8 +231,8 @@ take. Value objects are described in a section below.
 
 ### Value objects
 
-Value objects describe a value that is passed as an argument, either to a
-(positional) argument or an option.
+Value objects describe a value that is passed as an argument,
+either to a positional argument or an option.
 
 ```json
 {

--- a/specs/cli_introspection.md
+++ b/specs/cli_introspection.md
@@ -40,8 +40,8 @@ The schema is defined as
 
 ```json
 {
-    "mediaType" : "application/vnd.uapi-group.cli-introspection",
-    "commands": [<command object>, …]
+  "mediaType" : "application/vnd.uapi-group.cli-introspection",
+  "commands": [<command object>, …]
 }
 ```
 
@@ -62,41 +62,64 @@ e.g the basename of `argv[0]`,
 context,
 or in the context of scripting languages the name under which they are imported
 
-### Command ojects
+### Nomenclature
+
+A *CLI* is the textual interface that a program presents to a user.
+It consists of the program being called under a name followed by units that are
+separated by whitespace,
+these units are called *arguments*.
+
+Arguments may be single words or multiple words that may be escaped in some
+way in the case that they contain whitespace themselves,
+that is not meant to separate them from other arguments.
+
+Arguments describe the inputs to a program on the CLI.
+There are two types of arguments *positional arguments* and *optional arguments*.
+
+Positional arguments have a fixed position in relation to each other and to
+optional arguments.
+
+A special kind of positional argument is one that describes a command of its own.
+These will be called *verbs*,
+but are also known as subcommands.
+
+Optional arguments are also called options,
+which they will be called here for conciseness,
+as well as switches.
+
+### Command objects
 
 The command object is recursively defined as follows.
 
 ```json
 {
-    "names" : ["name1", "name2", …],
-    "argspec": ["value1", "value2", …]
-    "version": "myversion",
-    "features": ["feature1", "feature2", …]
-    "abstract": ["paragraph1", "paragraph2", …],
-    "postscript": ["paragraph1", "paragraph2", …],
-    "help": "short help"
-    "options": [<option object>, …],
-    "verbs": [<command >, …],
-    "documentation": ["doc1", …],
-    "project": "myproject",
-    "isDeprecated": false
+  "type": "command"
+  "names" : ["name1", "name2", …],
+  "version": ["myversion"],
+  "features": ["feature1", "feature2", …]
+  "abstract": ["paragraph1", "paragraph2", …],
+  "postscript": ["paragraph1", "paragraph2", …],
+  "help": "short help"
+  "arguments": [<option|argument|command>, …],
+  "documentation": ["doc1", …],
+  "project": "myproject",
+  "isDeprecated": false
 }
 ```
 
-All keys except `names` are optional and are treated as empty string or empty
-array when missing.
+All keys except `type` and `names` are optional and are treated as empty string
+or empty array when missing.
+
+`type` is the fixed string `command` and signals that this is a command object,
+describing either a top-level command or verb.
 
 `names` is a non-empty array of string names for that command.
 The first element of that array is the primary name of that command.
 Further names can be added as aliases,
 e.g. for backward compatibility.
 
-`argspec` is an array of argspec objects describing the arguments to the command
-after the name of the command,
-i.e. C language `argv` excluding the element with index 0.
-
-`version` defines the version string of the program.
-This string should be string compatible with UAPI.10 Version Format
+`version` is a an array describing the version of the program.
+The strings in this array should be compatible with the UAPI.10 Version Format
 Specification-compatible.
 
 `features` defines an array of strings that define builtin-in features of this
@@ -113,13 +136,13 @@ help output.
 usage information as well as for short descriptions of verbs in the list of
 options.
 
-`options` define a CLI's positional arguments and options and are described in a
-section below.
-
-`verbs` are command objects that describe a program's verbs,
-also called subcommands.
-Verbs may recursively define further verbs up to a maximum depth that should not
-be larger than 16.
+`arguments` defines a CLI's positional and optional arguments and are described
+below.
+It consists of *option objects*, *argument objects*, and *command  objects*.
+The depth of this object,
+since command objects in this array may themselves define command objects in
+their `arguments`,
+may not exceed 15.
 
 `documentation` is an array of string values describing URIs referencing
 documentation for this command,
@@ -132,70 +155,71 @@ This may the package that installed it or the project that produced it.
 
 `isDeprecated` is a boolean describing whether the command has been
 
-### Argspec objects
+### Argument objects
 
-Argspec objects describe the arguments passed to the program,
-specifically in what order verbs, arguments, and options are passed to the
-program.
+Argument objects describe positional arguments that are not verbs.
 
 ```json
 {
-    "name": "myname",
-    "value_name": "VALUE_NAME",
-    "type": "argument",
-    "optional": true,
-    "default": null
+  "type": "argument"
+  "name": "filename",
+  "value_name": "FILE",
+  "help": "Show this help",
+  "sections": ["Arguments"],
+  "values": [<value object>],
+  "isDeprecated": false
 }
 ```
 
-All keys except `name` and `type` are required and are treated as empty string,
-false or null if missing.
+All keys except `type`, `name` and `argument` are optional and are treated as
+empty when missing.
 
-`name` is a non-empty string describing the internal name of a value.
+`type` is the fixed string `argument` and signals that this is an argument object,
+describing a positional argument.
 
-`value_name` is a string describing the name that is shown in the argspec of the
-command.
-If it is empty, it defaults to the value of `name`.
-This concept is sometimes also called metavar.
+`names` is a non-empty string defining the name of the argument.
 
-`type` is a string describing what the argument is. It is either of
-- `argument`, a positional argument to the command,
-- `option`, which is command line switch from the `options` array of a command, or
-- `verb`, which is a verb from the `verbs` array of a command.
+`argument` defines the argument type, which is one of the strings:
+-`required_argument`, or
+-`optional_argument`.
+An argument object whose `argument` value is `required_argument` must be
+passed an argument,
+while an argument of whose `argument` value is `optional_argument` may be omitted.
 
-`optional` is a boolean describing whether an argspec object of type `argument`
-or `verb` must be passed or not.
+`help` is a string that defines the help text of the argument.
 
-`default` is a string or null,
-describing what the default value for this argument is.
-`null`, the default, means there is no default.
-`default` is ignored for argspec objects of type `option`.
-For argspec objects of type `verb` a non-`null` value must be a `name` of a
-commands object in the verbs array.
+`sections` is an array of string that defines sections in which this option should
+be shown.
+This is only for display-purposes.
 
-### Option objects
+`values` is an array of *value objects* describing the values this option may
+take.
+An empty array describes an argument that is a single arbitrary word.
+Value objects are described in a section below.
 
-Option objects arguments define both positional arguments as well as options,
-commonly prefixed with `-` or `--`,
-of a program.
-Both positional arguments and options will be referred to as options in this
-section,
-when a distinction is not explicitly made.
+`isDeprecated` is a boolean describing whether this option has been deprecated.
+
+### Option Objects
+
+Option objects describe optional arguments.
 
 ```json
 {
-    "names": ["-h","--help"],
-    "argument": "no_argument",
-    "help": "Show this help",
-    "group": [""],
-    "values": [<value object>],
-    "section": "option block 1",
-    "isDeprecated": false
+  "type": "option"
+  "names": ["-h","--help"],
+  "argument": "no_argument",
+  "help": "Show this help",
+  "sections": [""],
+  "values": [<value object>],
+  "isDeprecated": false
 }
 ```
 
-All keys except `names` and `argument` are optional and are treated as empty
-when missing.
+All keys except `type`, `names` and `argument` are optional and are treated as
+empty when missing.
+
+`type` is the fixed string `option` and signals that this is an option object,
+describing an optional argument.
 
 `names` is a non-empty array of strings defining the name of an option.
 Names starting with dashes define options and names not starting with dashes
@@ -205,50 +229,379 @@ but not both for the same object,
 i.e. an option object may not have names both with and without dashes.
 Options prefixed with a single dash (`-`) are called short options and options
 prefixed with two dashes (`--`) are called long options.
-Short options are usually followed by a single chracters,
+Short options are usually followed by a single character,
 whereas long options can be a longer string.
-Short otions may be followed by multiple characters,
+Short options may be followed by multiple characters,
 but this is discouraged.
 
 `argument` defines the argument type, which is one of the strings:
 -`no_argument`,
 -`required_argument`, or
 -`optional_argument`.
+An argument object whose `argument` value is `no_argument` cannot be passed an
+argument,
+an argument object whose `argument` value is `required_argument` must be
+passed an argument,
+and an argument of whose `argument` value is `optional_argument` may be omitted.
 
 `help` is a string that defines the help text of the option.
 
-`group` is an array of string that defines sections in which this option should
+`sections` is an array of string that defines sections in which this option should
 be shown.
 This is only for display-purposes.
 
 `values` is an array of *value objects* describing the values this option may
 take.
+An empty array describes an argument that is a single arbitrary word.
 Value objects are described in a section below.
-
-`section` is a string to visually group options into separate lists.
 
 `isDeprecated` is a boolean describing whether this option has been deprecated.
 
 ### Value objects
 
 Value objects describe a value that is passed as an argument,
-either to a positional argument or an option.
+either to a positional argument or an optional argument.
 
 ```json
 {
-    "name": "myname",
-    "help": "help text",
-    "default": true,
-    "isDeprecated": false
+  "type": "value",
+  "value": "myname",
+  "help": "help text",
+  "default": true,
+  "isDeprecated": false
 }
 ```
 
-All keys except `name` are optional and are treated as empty string or false
-when missing.
+All keys except `type` and `name` are optional and are treated as empty string
+or false when missing.
 
-`name` is a string describing the name of a value.
+`type` is the fixed string `value` and signals that this is a value object,
+describing an argument value.
+
+`value` is a string describing a possible value.
 
 `help` is a string describing the help text that should be shown for the value.
 
 `default` is a boolean describing whether this value is the default value for
 the option this is a value for.
+
+## Example
+
+This is an example for a description for `systemd-id128`, with the help output
+
+```console
+$ systemd-id128 --help
+> systemd-id128 [OPTION…] COMMAND …
+
+Generate and print 128-bit identifiers.
+
+Commands:
+  new                  Generate a new ID
+  machine-id           Print the ID of current machine
+  boot-id              Print the ID of current boot
+  invocation-id        Print the ID of current invocation
+  var-partition-uuid   Print the UUID for the /var/ partition
+  show [NAME|UUID]     Print one or more UUIDs
+  help                 Show this help
+
+Options:
+  -h --help            Show this help
+     --version         Show package version
+     --no-pager        Do not start a pager
+     --no-legend       Do not show headers and footers
+     --json=FORMAT     Output inspection data in JSON (takes one of pretty, short, off)
+  -j                   Equivalent to --json=pretty (on TTY) or --json=short (otherwise)
+  -p --pretty          Generate samples of program code
+  -P --value           Only print the value
+  -a --app-specific=ID Generate app-specific IDs
+  -u --uuid            Output in UUID format
+
+See the systemd-id128.1 man page for details.
+```
+
+The resulting CLI introspection JSON would be
+
+```json
+{
+  "mediaType": "application/vnd.io.systemd.cli-introspection-0",
+  "commands": [
+    {
+      "type": "command",
+      "names": [
+        "systemd-128"
+      ],
+      "version": [
+        "262",
+        "262~devel"
+      ],
+      "features": [
+        "PAM",
+        "+AUDIT",
+        "-SELINUX",
+        "+APPARMOR",
+        "-IMA",
+        "+IPE",
+        "+SMACK",
+        "+SECCOMP",
+        "+GCRYPT",
+        "+GNUTLS",
+        "+OPENSSL",
+        "+ACL",
+        "+BLKID",
+        "+CURL",
+        "+ELFUTILS",
+        "+FIDO2",
+        "+IDN2",
+        "+KMOD",
+        "+LIBCRYPTSETUP",
+        "+LIBCRYPTSETUP",
+        "PLUGINS",
+        "+LIBFDISK",
+        "+PCRE2",
+        "+PWQUALITY",
+        "+P11KIT",
+        "+QRENCODE",
+        "+TPM2",
+        "+BZIP2",
+        "+LZ4",
+        "+XZ",
+        "+ZLIB",
+        "+ZSTD",
+        "+BPF",
+        "FRAMEWORK",
+        "+BTF",
+        "+XKBCOMMON",
+        "+UTMP",
+        "+LIBARCHIVE"
+      ],
+      "documentation": [
+        "https://www.freedesktop.org/software/systemd/man/latest/systemd-id128.html",
+        "man:systemd-id128(1)"
+      ],
+      "abstract": [
+        "Generate and print 128-bit identifiers."
+      ],
+      "postscript": [
+        "See the systemd-id128(1) man page for details."
+      ],
+      "arguments": [
+        {
+          "type": "option",
+          "names": [
+            "-h",
+            "--help"
+          ],
+          "argument": "no_argument",
+          "sections": [
+            "Options"
+          ],
+          "help": "Show this help"
+        },
+        {
+          "type": "option",
+          "names": [
+            "--version"
+          ],
+          "argument": "no_argument",
+          "sections": [
+            "Options"
+          ],
+          "help": "Show package version"
+        },
+        {
+          "type": "option",
+          "names": [
+            "--no-pager"
+          ],
+          "argument": "no_argument",
+          "sections": [
+            "Options"
+          ],
+          "help": "Do not start a pager"
+        },
+        {
+          "type": "option",
+          "names": [
+            "--no-legend"
+          ],
+          "argument": "no_argument",
+          "sections": [
+            "Options"
+          ],
+          "help": "Do not show headers and footers"
+        },
+        {
+          "type": "option",
+          "names": [
+            "--json"
+          ],
+          "argument": "required_argument",
+          "value_name": "FORMAT",
+          "sections": [
+            "Options"
+          ],
+          "help": "Output inspection data in JSON (takes one of pretty, short, off)",
+          "values": [
+            {
+              "type": "value",
+              "value": "short",
+              "help": "the shortest possible output without any redundant whitespace or line breaks"
+            },
+            {
+              "type": "value",
+              "value": "pretty",
+              "help": "a pretty version of the same"
+            },
+            {
+              "type": "value",
+              "value": "off",
+              "help": "no JSON output",
+              "default": true
+            }
+          ]
+        },
+        {
+          "type": "option",
+          "names": [
+            "-j"
+          ],
+          "argument": "no_argument",
+          "sections": [
+            "Options"
+          ],
+          "help": "Equivalent to --json=pretty (on TTY) or --json=short (otherwise)"
+        },
+        {
+          "type": "option",
+          "names": [
+            "-p",
+            "--pretty"
+          ],
+          "argument": "no_argument",
+          "sections": [
+            "Options"
+          ],
+          "help": "Generate samples of program code"
+        },
+        {
+          "type": "option",
+          "names": [
+            "-P",
+            "--value"
+          ],
+          "argument": "no_argument",
+          "sections": [
+            "Options"
+          ],
+          "help": "Only print the value"
+        },
+        {
+          "type": "option",
+          "names": [
+            "-a",
+            "--app-specific"
+          ],
+          "value_name": "ID",
+          "argument": "required_argument",
+          "sections": [
+            "Options"
+          ],
+          "help": "Generate app-specific IDs"
+        },
+        {
+          "type": "option",
+          "names": [
+            "-u",
+            "--uuid"
+          ],
+          "sections": [
+            "Options"
+          ],
+          "help": "Output in UUID format"
+        },
+        {
+          "type": "command",
+          "name": [
+            "new"
+          ],
+          "help": "Generate a new ID"
+        },
+        {
+          "type": "command",
+          "name": [
+            "machine-id"
+          ],
+          "value_name": "COMMAND",
+          "sections": [
+            "Commands"
+          ],
+          "help": "Print the ID of current machine"
+        },
+        {
+          "type": "command",
+          "name": [
+            "boot-id"
+          ],
+          "value_name": "COMMAND",
+          "sections": [
+            "Commands"
+          ],
+          "help": "Print the ID of current boot"
+        },
+        {
+          "type": "command",
+          "name": [
+            "invocation-id"
+          ],
+          "value_name": "COMMAND",
+          "sections": [
+            "Commands"
+          ],
+          "help": "Print the ID of current invocation"
+        },
+        {
+          "type": "command",
+          "name": [
+            "var-partition-uuid"
+          ],
+          "value_name": "COMMAND",
+          "sections": [
+            "Commands"
+          ],
+          "help": "Print the UUID for the /var/ partition"
+        },
+        {
+          "type": "command",
+          "name": [
+            "show"
+          ],
+          "value_name": "COMMAND",
+          "sections": [
+            "Commands"
+          ],
+          "arguments": [
+            {
+              "type": "argument",
+              "name": "name_or_uuid",
+              "argument": "optional_argument"
+              "value_name": "NAME|UUID"
+            }
+          ],
+          "help": "Print one or more UUIDs"
+        },
+        {
+          "type": "command",
+          "name": [
+            "help"
+          ],
+          "value_name": "COMMAND",
+          "sections": [
+            "Commands"
+          ],
+          "help": "Show this help"
+        }
+      ]
+    }
+  ]
+}
+```


### PR DESCRIPTION
This is a draft that @keszybz based his work in https://github.com/systemd/systemd/pull/43152 on (with a few typos) fixed. A few commits have been put on top addressing a few things that where found during the review of that PR already and that were commented on https://github.com/behrmann/uapi-specifications/commit/e7911dc962f2c7bedf6bc8a0218912b86e07f3af#comments. It also adds what's currently pending in https://github.com/systemd/systemd/pull/43430. 

The idea is to have a JSON schema that describes the full output (or a superset of that) that one would get from a binary via `--help` in a structured way. The idea is that this would allow to automatically generate command line completion from this, which we have already done in mkosi, but would also allow other things, like checking for features of a command line program without resorting to brittle parsing of help output.

This is still very much work in progress.